### PR TITLE
added cuda spectrometer test and benchmark

### DIFF
--- a/source/cpp_src/CUDASpectrometer/include/spectrometer.h
+++ b/source/cpp_src/CUDASpectrometer/include/spectrometer.h
@@ -73,7 +73,10 @@ __global__ void short_to_float_s(int16_t *ds, float *df, int n_spectra, int spec
 __global__ void apply_weights(float *df, float *w, int n_spectra, int spectrum_length);
 __global__ void square_and_accumulate_sum(cufftComplex *z, float *spectrum);
 
+/* calculate spectra and pwr */
 extern "C" void process_vector_no_output(SAMPLE_TYPE *d_in, spectrometer_data *d);
+/* do_squared_pwr=1 also estimated power with \sum_n x_n**2 */
+extern "C" void process_vector_no_output_(SAMPLE_TYPE *d_in, spectrometer_data *d, int do_squared_pwr);
 extern "C" spectrometer_data *new_spectrometer_data(int data_length, int spectrum_length, int window_flag);
 extern "C" void free_spectrometer_data(spectrometer_data *d);
 

--- a/source/cpp_src/Test/Makefile
+++ b/source/cpp_src/Test/Makefile
@@ -1,0 +1,6 @@
+benchmark: benchmark.cu ../CUDASpectrometer/src/spectrometer.cu  ../CUDASpectrometer/src/noise_statistics_mbp_reduce.cu
+	nvcc -DHOSE_USE_ADQ7 -I../CUDASpectrometer/include -o benchmark ../CUDASpectrometer/src/spectrometer.cu benchmark.cu ../CUDASpectrometer/src/noise_statistics_mbp_reduce.cu -lcufft
+
+test: benchmark validate.py
+	./benchmark
+	python3 validate.py

--- a/source/cpp_src/Test/benchmark.cu
+++ b/source/cpp_src/Test/benchmark.cu
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include "spectrometer.h"
+#include <cmath>
+#include <random>
+#include <inttypes.h>
+#include <chrono>
+#include <iostream>
+int main(int argc, char **argv)
+{
+  printf("running a benchmark\n");
+  int veclen=2097152*64;
+  int fftlen=2097152;
+  spectrometer_data* sd = new_spectrometer_data(veclen, fftlen, 0);
+  int16_t *noise; 
+  std::random_device rd{};
+  std::mt19937 gen{rd()};
+  
+  
+  std::normal_distribution d{0.0,1.0};
+  auto random_short = [&d, &gen]{return std::round(512*d(gen));};
+  
+  noise=(int16_t *)malloc(sizeof(int16_t)*veclen);
+  
+  for(int i=0; i<veclen; i++)
+  {
+	noise[i]=random_short();
+  }
+  FILE *o=fopen("noise.bin","wb");
+  fwrite(noise,sizeof(int16_t),veclen,o);
+  fclose(o);
+
+  process_vector_no_output_(noise, sd, 0);
+  o=fopen("spec.bin","wb");  
+  fwrite(sd->spectrum,sizeof(float),sd->spectrum_length/2+1,o);
+  fclose(o);
+  
+  typedef std::chrono::high_resolution_clock Time;
+  typedef std::chrono::milliseconds ms;
+  typedef std::chrono::duration<float> fsec;
+  auto t0 = Time::now();
+  
+  
+
+  
+  long n_reps=10;
+  long n_samples = n_reps*veclen;
+  for(int i=0; i<n_reps; i++)
+  {
+    process_vector_no_output_(noise, sd, 0);
+  }
+
+  
+  auto t1 = Time::now();
+  fsec fs = t1 - t0;
+  ms td = std::chrono::duration_cast<ms>(fs);
+  double samps_per_sec=(double)n_samples/fs.count();
+  std::cout << samps_per_sec << "samps per second\n";
+  std::cout << fs.count() << "s\n";
+  std::cout << td.count() << "ms\n";
+}

--- a/source/cpp_src/Test/validate.py
+++ b/source/cpp_src/Test/validate.py
@@ -1,0 +1,29 @@
+import numpy as n
+import matplotlib.pyplot as plt
+import scipy.signal as ss
+import time
+
+s=n.array(n.fromfile("noise.bin",dtype=n.int16),dtype=n.float32)/65535.0
+nspec=64
+fftlen=2097152
+wf=ss.blackmanharris(fftlen)
+
+tmp=n.fft.rfft(n.zeros(fftlen))
+S=n.zeros(len(tmp))
+t0=time.time()
+for i in range(nspec):
+    S+=n.abs(n.fft.rfft(s[(i*fftlen):(i*fftlen+fftlen)]))**2.0
+t1=time.time()
+samps_per_sec=(nspec*fftlen)/(t1-t0)
+print("sr %1.2g"%(samps_per_sec))
+
+gpus=n.fromfile("spec.bin",dtype=n.float32)
+
+plt.plot((S[0:int(fftlen/2)]-gpus[0:int(fftlen/2)])/S[0:int(fftlen/2)])
+plt.xlabel("Frequency bin")
+plt.ylabel("Relative difference $(P_0(\omega)-P_1(\omega))/P_0(\omega)$")
+plt.show()
+
+plt.plot(10.0*n.log10(S[0:int(fftlen/2)]))
+plt.plot(10.0*n.log10(gpus[0:int(fftlen/2)]))
+plt.show()


### PR DESCRIPTION
Added a test and benchmark for the cuda spectrometer module. With an RTX A5000 about 1.8 GHz sample-rate is possible. The python validate.py script is used to compare the spectrum calculated with python and numpy with that calculated by the cuda code. They should both be the same (and they are in the test case). 